### PR TITLE
Convert ssl_mode param to integer

### DIFF
--- a/contrib/ruby/.gitignore
+++ b/contrib/ruby/.gitignore
@@ -4,3 +4,4 @@
 /tmp
 /vendor/gems
 /pkg
+.ruby-version

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -9,6 +9,7 @@ require "trilogy/encoding"
 class Trilogy
   def initialize(options = {})
     options[:port] = options[:port].to_i if options[:port]
+    options[:ssl_mode] = options[:ssl_mode].to_i if options[:ssl_mode]
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)
     charset = Trilogy::Encoding.charset(mysql_encoding)


### PR DESCRIPTION
## Description

While passing the option parameters to the Trilogy class initializer, an `ssl_mode` parameter is not converted to the integer, therefore it fails to initialize the MySQL client properly. 

While this might not be a perfect solution, it does work as expected while using the Trilogy together with Rails 8. It might be a better option to handle this conversion while initializing the ActiveRecord